### PR TITLE
Changing the Server from HTTP to HTTPS

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,12 @@
 var static = require('node-static');
-var http = require('http');
+var https = require('https');
 var file = new(static.Server)();
-var app = http.createServer(function(req, res) {
+var fs = require('fs');
+var options = {
+    key: fs.readFileSync('HTTPS_Permissions/key.pem'),
+    cert: fs.readFileSync('HTTPS_Permissions/cert.pem')
+};  // Here the Permissions related to HTTPS are stored in the HTTPS_Permissions Folder
+var app = https.createServer(function(req, res) {
     file.serve(req, res);
 }).listen(process.env.PORT || 3000);
 

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ var options = {
     key: fs.readFileSync('HTTPS_Permissions/key.pem'),
     cert: fs.readFileSync('HTTPS_Permissions/cert.pem')
 };  // Here the Permissions related to HTTPS are stored in the HTTPS_Permissions Folder
-var app = https.createServer(function(req, res) {
+var app = https.createServer( options, function(req, res) {
     file.serve(req, res);
 }).listen(process.env.PORT || 3000);
 


### PR DESCRIPTION
WebRTC Javascript API functions, namely GetUserMedia no longer work with HTTP. The File has to be hosted on a HTTPS server for the Functions to work.
Hence, I changed the Server from a HTTP to a HTTPS server.
The HTTPS Permission Files namely key.pem and cert.pem have to be obtained.
Only then will this Chat Application work. On a HTTP Server, the GetUserMedia will not load, hence one will not be able to capture feed in the first place.
For requiring HTTPS permissions for Testing use, check out : 
http://stackoverflow.com/questions/12871565/how-to-create-pem-files-for-https-web-server
and
http://stackoverflow.com/questions/10175812/how-to-create-a-self-signed-certificate-with-openssl

Hope this helps.